### PR TITLE
feat(ui): sanitize snake preview html

### DIFF
--- a/packages/ui/src/components/SnakePreview.tsx
+++ b/packages/ui/src/components/SnakePreview.tsx
@@ -1,14 +1,33 @@
+import { useMemo } from "react";
+import { sanitizeSvgContent } from "../utils/sanitizeSvg";
+
 export interface SnakePreviewProps {
   svgContent: string;
   className?: string;
+  /**
+   * Render raw SVG without sanitization. For trusted, internal-only content.
+   */
+  unsafe?: boolean;
 }
 
-export function SnakePreview({ svgContent, className = "" }: SnakePreviewProps) {
+/**
+ * Displays provided SVG markup after sanitization to avoid XSS in previews.
+ */
+export function SnakePreview({
+  svgContent,
+  className = "",
+  unsafe = false,
+}: SnakePreviewProps) {
+  const safeSvg = useMemo(
+    () => (unsafe ? svgContent : sanitizeSvgContent(svgContent)),
+    [svgContent, unsafe],
+  );
+
   return (
     <div
       className={`overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800 ${className}`}
       // biome-ignore lint/security/noDangerouslySetInnerHtml: SVG content is sanitized
-      dangerouslySetInnerHTML={{ __html: svgContent }}
+      dangerouslySetInnerHTML={{ __html: safeSvg }}
     />
   );
 }

--- a/packages/ui/src/utils/sanitizeSvg.test.ts
+++ b/packages/ui/src/utils/sanitizeSvg.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeSvgContent } from "./sanitizeSvg";
+
+describe("sanitizeSvgContent", () => {
+  test("removes script tags from SVG markup", () => {
+    const dirtySvg =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><script>alert("xss")</script><rect width="10" height="10" fill="blue" /></svg>';
+
+    const sanitized = sanitizeSvgContent(dirtySvg);
+
+    expect(sanitized).not.toContain("<script");
+    expect(sanitized).toContain("<rect");
+  });
+});

--- a/packages/ui/src/utils/sanitizeSvg.ts
+++ b/packages/ui/src/utils/sanitizeSvg.ts
@@ -1,0 +1,55 @@
+const UNSAFE_PROTOCOL = /^javascript:/i;
+
+const isDomParserAvailable = typeof DOMParser !== "undefined";
+
+/**
+ * Sanitizes SVG markup by removing scripts and dangerous attributes.
+ */
+export function sanitizeSvgContent(svgContent: string): string {
+  if (!svgContent) {
+    return "";
+  }
+
+  if (!isDomParserAvailable) {
+    return stripScriptTags(svgContent);
+  }
+
+  const parser = new DOMParser();
+  const parsed = parser.parseFromString(svgContent, "image/svg+xml");
+  const root = parsed.documentElement;
+
+  if (root.nodeName === "parsererror") {
+    return "";
+  }
+
+  parsed.querySelectorAll("script").forEach((node) => node.remove());
+
+  const walker = parsed.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+  let current: Element | null = root;
+
+  while (current) {
+    Array.from(current.attributes).forEach((attribute) => {
+      const name = attribute.name.toLowerCase();
+      const value = attribute.value.trim();
+
+      if (name.startsWith("on")) {
+        current?.removeAttribute(attribute.name);
+        return;
+      }
+
+      if (isUnsafeHref(name, value)) {
+        current?.removeAttribute(attribute.name);
+      }
+    });
+
+    current = walker.nextNode() as Element | null;
+  }
+
+  return root.outerHTML;
+}
+
+const isUnsafeHref = (name: string, value: string) =>
+  (name === "href" || name === "xlink:href") && UNSAFE_PROTOCOL.test(value);
+
+const stripScriptTags = (content: string) =>
+  content.replaceAll(/<script[\s\S]*?<\/script>/gi, "");

--- a/packages/ui/src/utils/sanitizeSvg.ts
+++ b/packages/ui/src/utils/sanitizeSvg.ts
@@ -51,5 +51,14 @@ export function sanitizeSvgContent(svgContent: string): string {
 const isUnsafeHref = (name: string, value: string) =>
   (name === "href" || name === "xlink:href") && UNSAFE_PROTOCOL.test(value);
 
-const stripScriptTags = (content: string) =>
-  content.replaceAll(/<script[\s\S]*?<\/script>/gi, "");
+const stripScriptTags = (content: string) => {
+  let previous: string;
+  let current = content;
+
+  do {
+    previous = current;
+    current = current.replace(/<script[\s\S]*?<\/script>/gi, "");
+  } while (current !== previous);
+
+  return current;
+};

--- a/packages/ui/src/utils/sanitizeSvg.ts
+++ b/packages/ui/src/utils/sanitizeSvg.ts
@@ -57,7 +57,7 @@ const stripScriptTags = (content: string) => {
 
   do {
     previous = current;
-    current = current.replace(/<script[\s\S]*?<\/script>/gi, "");
+    current = current.replace(/<script\b[\s\S]*?<\/script[^>]*>/gi, "");
   } while (current !== previous);
 
   return current;


### PR DESCRIPTION
## Summary
- sanitize SVG content before rendering SnakePreview and add an opt-in unsafe mode for trusted markup
- introduce a reusable SVG sanitizer tailored for script and event-handler removal
- add a unit test confirming scripts are stripped from provided SVG

## Testing
- bun test packages/ui/src/utils/sanitizeSvg.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6946a7a3cf88832ea0215f44409af272)