### PR TITLE
Clarify GIF support and validate CLI formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npx @snake-evolution/cli generate -u YOUR_USERNAME -o snake.svg
 
 ## ✨ Why Snake Evolution?
 
-- **🎨 7 Beautiful Themes** - Match your profile's aesthetic
+- **🎨 6 Beautiful Themes** - Match your profile's aesthetic (Glass arrives with GIF support)
 - **🧠 Smart Pathfinding** - Snake hunts high-value contributions first
 - **⚡ Zero-Install CLI** - `npx @snake-evolution/cli@latest` - no setup needed
 - **🤖 GitHub Action** - Automated daily updates
@@ -120,15 +120,9 @@ Explore all available themes:
 
 ![Cypherpunk](./assets/examples/cypherpunk.svg)
 
-### 🧊 Glass (GIF only)
+### 🧊 Glass (Coming Soon)
 
-> ⚠️ **Note:** Glass theme uses blur/transparency effects that require GIF output. SVG cannot render these effects properly.
-
-*Coming with GIF support in v1.1*
-
-```bash
-bun run generate -u YOUR_USERNAME -t ocean -o snake.svg
-```
+> GIF rendering is still in progress. The Glass theme will unlock once GIF output is available.
 
 ---
 
@@ -228,8 +222,11 @@ bun add @snake-evolution/cli
 | `-u, --username` | GitHub username | *required* |
 | `-o, --output` | Output file path | `snake.svg` |
 | `-t, --theme` | Color theme | `github-dark` |
+| `-f, --format` | Output format (svg only; GIF not supported yet) | `svg` |
 | `-y, --year` | Year to generate | current |
 | `--static` | No animation | `false` |
+
+> ℹ️ GIF output is not available yet. The CLI will stop with a clear error if you request `--format gif` or the Glass theme.
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -16,12 +16,12 @@ inputs:
     default: ''
 
   outputs:
-    description: 'Output file path(s), comma-separated for multiple formats'
+    description: 'Output file path(s) - SVG only while GIF support is in progress'
     required: false
     default: 'dist/snake.svg'
 
   theme:
-    description: 'Color theme (github-light, github-dark, ocean, sunset, neon-gamer, cypherpunk)'
+    description: 'Color theme (github-light, github-dark, ocean, sunset, neon-gamer, cypherpunk; glass planned with future GIF support)'
     required: false
     default: 'github-dark'
 

--- a/apps/web/src/content/docs/architecture/overview.md
+++ b/apps/web/src/content/docs/architecture/overview.md
@@ -28,7 +28,7 @@ snake-evolution/
 ├── packages/
 │   ├── types/            # Shared TypeScript types
 │   ├── engine/           # Snake game logic
-│   ├── renderer/         # SVG/GIF rendering
+│   ├── renderer/         # SVG rendering (GIF planned)
 │   ├── github/           # GitHub API client
 │   └── ui/               # React components
 └── docker/               # Docker setup
@@ -43,7 +43,7 @@ packages/github (fetch contributions)
     ↓
 packages/engine (calculate snake path)
     ↓
-packages/renderer (generate SVG/GIF)
+packages/renderer (generate SVG; GIF planned)
     ↓
 Output file or API response
 ```
@@ -62,9 +62,9 @@ The engine calculates the optimal path for the snake:
 
 Supports multiple output formats:
 
-- **SVG** - Vector graphics, scales perfectly
-- **GIF** - Animated, compatible everywhere
-- **PNG** - Static image for embedding
+- **SVG** - Vector graphics, scales perfectly (current)
+- **GIF** - Planned animated output
+- **PNG** - Planned static raster output
 
 ### GitHub Client
 

--- a/apps/web/src/content/docs/guides/customization.md
+++ b/apps/web/src/content/docs/guides/customization.md
@@ -91,14 +91,9 @@ outputs: dist/snake.svg?
   rounded=true
 ```
 
-### GIF Options
+### GIF Options (Planned)
 
-```yaml
-outputs: dist/snake.gif?
-  animated=true&
-  loop=true&
-  quality=high
-```
+GIF rendering is not available yet. Stick with SVG outputs until GIF support lands.
 
 ## Environment Variables
 

--- a/apps/web/src/content/docs/guides/github-action.md
+++ b/apps/web/src/content/docs/guides/github-action.md
@@ -32,22 +32,18 @@ jobs:
 |-------|-------------|---------|
 | `github_user_name` | GitHub username to generate snake for | Required |
 | `github_token` | GitHub token for API access | `${{ github.token }}` |
-| `outputs` | Output file paths and formats | `dist/snake.svg` |
-| `palette` | Color palette name | `github` |
-| `animated` | Enable animation | `false` |
+| `outputs` | Output file paths (SVG only) | `dist/snake.svg` |
+| `theme` | Color theme | `github-dark` |
+| `year` | Contribution year | Current year |
 
 ## Output Formats
+
+> GIF output is not available yet. Use SVG outputs until GIF rendering ships.
 
 ### Static SVG
 
 ```yaml
 outputs: dist/snake.svg
-```
-
-### Animated GIF
-
-```yaml
-outputs: dist/snake.gif?animated=true
 ```
 
 ### Multiple Outputs
@@ -56,7 +52,6 @@ outputs: dist/snake.gif?animated=true
 outputs: |
   dist/snake.svg
   dist/snake-dark.svg?palette=github-dark
-  dist/snake.gif?animated=true&palette=ocean
 ```
 
 ## Full Example
@@ -87,7 +82,6 @@ jobs:
           outputs: |
             dist/snake.svg
             dist/snake-dark.svg?palette=github-dark
-            dist/snake.gif?animated=true
 
       - name: Push to output branch
         uses: crazy-max/ghaction-github-pages@v4

--- a/apps/web/src/content/docs/guides/installation.md
+++ b/apps/web/src/content/docs/guides/installation.md
@@ -60,7 +60,7 @@ snake-evolution/
 ├── packages/
 │   ├── types/        # Shared TypeScript types
 │   ├── engine/       # Snake game logic
-│   ├── renderer/     # SVG/GIF rendering
+│   ├── renderer/     # SVG rendering (GIF planned)
 │   ├── github/       # GitHub API client
 │   └── ui/           # Shared React components
 └── docker/           # Docker setup

--- a/apps/web/src/content/docs/guides/quick-start.md
+++ b/apps/web/src/content/docs/guides/quick-start.md
@@ -33,7 +33,6 @@ jobs:
           outputs: |
             dist/snake.svg
             dist/snake-dark.svg?palette=github-dark
-            dist/snake.gif?animated=true
 
       - uses: actions/upload-artifact@v4
         with:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,7 @@ GitHub API → packages/github → packages/engine → packages/renderer → SVG
 ## Planned Data Flow (v2.0+)
 
 ```
-GitHub API → packages/github → packages/engine → packages/renderer → Output (SVG/GIF)
+GitHub API → packages/github → packages/engine → packages/renderer → Output (SVG; GIF planned)
                                      ↓
                               Evolu (local-first storage)
                                      ↓

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,7 @@ Make Snake Evolution the most fun way to visualize GitHub contributions - from s
 **What's Live:**
 
 - ✅ CLI tool with npm support (`npx @snake-evolution/cli@latest`)
-- ✅ 7 stunning themes (6 SVG + 1 GIF-only glass theme)
+- ✅ 6 stunning themes (Glass planned once GIF rendering ships)
 - ✅ GitHub Action for automated generation
 - ✅ Smart pathfinding (priority-based hunting - eats darkest squares first)
 - ✅ Smooth SMIL animations with visual gradient

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,7 +53,7 @@ snake themes
 | `-o, --output <path>` | Output file path | `snake.svg` |
 | `-t, --theme <name>` | Color theme | `github-dark` |
 | `-y, --year <year>` | Year to generate | current year |
-| `-f, --format <format>` | Output format (svg, gif) | `svg` |
+| `-f, --format <format>` | Output format (svg only; GIF not supported yet) | `svg` |
 | `--static` | Generate static SVG (no animation) | `false` |
 | `--frame-delay <ms>` | Delay between frames | `150` |
 | `--token <token>` | GitHub token for higher rate limits | - |
@@ -68,7 +68,7 @@ snake themes
 | `sunset` | Warm sunset vibes |
 | `neon-gamer` | Vibrant neon purple/green |
 | `cypherpunk` | Blue/magenta cyberpunk vibes |
-| `glass` | Liquid glass effect (requires GIF output, coming soon) |
+| `glass` | Planned liquid glass effect (blocked until GIF output is available) |
 
 ## Examples
 
@@ -177,7 +177,7 @@ snake generate -u YOUR_USERNAME
 
 ### Theme Not Rendering
 
-Glass theme requires GIF output (coming in v1.3):
+Glass theme is temporarily disabled until GIF output lands:
 
 ```bash
 # Use alternative themes for SVG

--- a/packages/cli/src/format.test.ts
+++ b/packages/cli/src/format.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { validateOutputFormat } from "./format";
+
+describe("validateOutputFormat", () => {
+  test("rejects gif format with helpful hint", () => {
+    const result = validateOutputFormat("gif", "github-dark");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("GIF output is not supported");
+      expect(result.hint).toContain("format svg");
+    }
+  });
+
+  test("rejects glass theme until gif support is ready", () => {
+    const result = validateOutputFormat("svg", "glass");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("glass theme");
+      expect(result.hint).toContain("cypherpunk");
+    }
+  });
+
+  test("rejects unknown formats", () => {
+    const result = validateOutputFormat("png", "github-dark");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("Unsupported format \"png\"");
+      expect(result.hint).toContain("Use --format svg");
+    }
+  });
+
+  test("accepts svg by default", () => {
+    const result = validateOutputFormat(undefined, "github-dark");
+
+    expect(result).toEqual({ ok: true, normalizedFormat: "svg" });
+  });
+});

--- a/packages/cli/src/format.test.ts
+++ b/packages/cli/src/format.test.ts
@@ -27,7 +27,7 @@ describe("validateOutputFormat", () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.reason).toContain("Unsupported format \"png\"");
+      expect(result.reason).toContain('Unsupported format "png"');
       expect(result.hint).toContain("Use --format svg");
     }
   });

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -1,0 +1,41 @@
+/**
+ * Validates output format requests so we can give users clear guidance instead of silent fallbacks.
+ */
+export function validateOutputFormat(
+  rawFormat: string | undefined,
+  theme: string | undefined,
+):
+  | { ok: true; normalizedFormat: "svg" }
+  | { ok: false; normalizedFormat: string; reason: string; hint?: string } {
+  const normalizedFormat = (rawFormat ?? "svg").toLowerCase();
+  const normalizedTheme = (theme ?? "").toLowerCase();
+
+  if (normalizedFormat === "gif") {
+    return {
+      ok: false,
+      normalizedFormat,
+      reason: "GIF output is not supported yet.",
+      hint: "Use --format svg for now.",
+    };
+  }
+
+  if (normalizedTheme === "glass") {
+    return {
+      ok: false,
+      normalizedFormat,
+      reason: "The glass theme depends on GIF rendering, which is currently unavailable.",
+      hint: "Choose another theme such as cypherpunk until GIF support ships.",
+    };
+  }
+
+  if (normalizedFormat !== "svg") {
+    return {
+      ok: false,
+      normalizedFormat,
+      reason: `Unsupported format "${normalizedFormat}". Only svg is available right now.`,
+      hint: "Use --format svg while we build out additional outputs.",
+    };
+  }
+
+  return { ok: true, normalizedFormat: "svg" };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import { getTheme, renderAnimatedSVG, renderStaticSVG } from "@snake-evolution/r
 import { Command } from "commander";
 
 import data from "../package.json";
+import { validateOutputFormat } from "./format";
 
 const pkg = { version: data.version };
 
@@ -29,7 +30,7 @@ program
     "Theme name (github-light, github-dark, ocean, sunset, neon-gamer, cypherpunk, glass)",
     "github-dark",
   )
-  .option("-f, --format <format>", "Output format (svg, gif)", "svg")
+  .option("-f, --format <format>", "Output format (svg only for now)", "svg")
   .option("-y, --year <year>", "Year to generate for", String(new Date().getFullYear()))
   .option("--token <token>", "GitHub personal access token for higher rate limits")
   .option("--animated", "Generate animated SVG (default: true)", true)
@@ -46,14 +47,14 @@ program
     console.log("");
 
     try {
-      // Block glass theme for SVG (too heavy, freezes PC)
-      if (options.theme === "glass" && options.format !== "gif") {
-        console.error("❌ Error: Glass theme requires GIF output format.");
-        console.error("   Glass uses blur/transparency effects that are too heavy for SVG.");
-        console.error("   GIF support coming in v1.1. For now, try: --theme cypherpunk");
+      const formatCheck = validateOutputFormat(options.format, options.theme);
+      if (!formatCheck.ok) {
+        console.error("❌ Error:", formatCheck.reason);
+        if (formatCheck.hint) {
+          console.error(`   ${formatCheck.hint}`);
+        }
         process.exit(1);
       }
-
       // Fetch contributions
       console.log("📊 Fetching GitHub contributions...");
       const grid = await fetchContributions(
@@ -84,10 +85,7 @@ program
         frameDelay: Number.parseInt(options.frameDelay, 10),
       };
 
-      if (options.format === "gif") {
-        console.log("🎬 GIF generation not yet implemented, falling back to animated SVG");
-        output = renderAnimatedSVG(frames, renderOptions);
-      } else if (options.static) {
+      if (options.static) {
         console.log("🖼️  Rendering static SVG...");
         const lastFrame = frames[frames.length - 1];
         if (lastFrame) {
@@ -127,7 +125,7 @@ program
     console.log("  sunset        - Warm sunset vibes");
     console.log("  neon-gamer    - Vibrant neon purple/green");
     console.log("  cypherpunk    - Blue/magenta cyberpunk vibes");
-    console.log("  glass         - Liquid glass effect (requires GIF output)");
+    console.log("  glass         - Liquid glass effect (coming when GIF output ships)");
   });
 
 program.parse();

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1,4 +1,4 @@
-// Snake Evolution - SVG/GIF Renderer
+// Snake Evolution - SVG Renderer (GIF planned)
 
 import type {
   ColorPalette,


### PR DESCRIPTION
## Summary
- add CLI-side format validation so GIF, glass, and other unsupported outputs fail fast with guidance
- synchronize README, CLI docs, roadmap, and action examples to state GIF output is not available yet
- mark renderer docs as SVG-only for now while GIF/PNG remain planned
- clarify GitHub Action inputs to note SVG-only outputs until GIF support lands

## Testing
- bun test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6946a7c4c2f0832e9b8b615bf480d2e4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated guides to clarify that GIF rendering is a planned feature, not currently available
  * Removed GIF-related examples from workflows and configuration documentation
  * Clarified SVG as the current supported output format

* **Tests**
  * Added validation tests for output format handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->