### PR TITLE
Support multi-output invocation for GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,10 @@ jobs:
       - uses: miccy/snake-evolution@v1
         with:
           github_user_name: ${{ github.repository_owner }}
-          outputs: dist/snake.svg
+          outputs: |
+            dist/snake.svg
+            dist/snake-dark.svg?palette=github-dark
+            dist/snake.gif?palette=ocean&format=gif
           theme: github-dark
 
       - name: Commit and Push
@@ -176,6 +179,8 @@ Then in your **README.md**:
 ```markdown
 ![Snake](./dist/snake.svg)
 ```
+
+**Outputs input:** You can provide multiple outputs separated by commas or new lines. Each entry is written inside `github.workspace` and can optionally include query params for per-output overrides, e.g. `dist/snake.svg?palette=ocean&format=svg`.
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ''
 
   outputs:
-    description: 'Output file path(s), comma-separated for multiple formats'
+    description: 'Output file path(s), comma or newline separated. Append ?palette=<theme>&format=<svg|gif> per output to override.'
     required: false
     default: 'dist/snake.svg'
 
@@ -54,7 +54,7 @@ runs:
       shell: bash
       run: |
         # Parse inputs
-        OUTPUT="${{ inputs.outputs }}"
+        OUTPUTS_RAW="${{ inputs.outputs }}"
         THEME="${{ inputs.theme }}"
         YEAR="${{ inputs.year }}"
         USERNAME="${{ inputs.github_user_name }}"
@@ -62,23 +62,68 @@ runs:
         ACTION_PATH="${{ github.action_path }}"
         WORKSPACE="${{ github.workspace }}"
 
-        # Build output path (relative to workspace, not action path)
-        OUTPUT_PATH="${WORKSPACE}/${OUTPUT}"
+        # Split outputs on commas and newlines
+        mapfile -t OUTPUTS <<< "$(printf '%s\n' "$OUTPUTS_RAW" | tr ',' '\n')"
 
-        # Build command (run from action path, output to workspace)
-        CMD="bun run ${ACTION_PATH}/packages/cli/src/index.ts generate -u $USERNAME -t $THEME -o $OUTPUT_PATH"
+        # Base CLI command (run from action path)
+        CMD_BASE=(bun run "${ACTION_PATH}/packages/cli/src/index.ts" generate -u "$USERNAME")
 
         if [ -n "$YEAR" ]; then
-          CMD="$CMD -y $YEAR"
+          CMD_BASE+=( -y "$YEAR" )
         fi
 
         if [ -n "$TOKEN" ]; then
-          CMD="$CMD --token $TOKEN"
+          CMD_BASE+=( --token "$TOKEN" )
         fi
 
-        # Run generation
-        echo "Running: $CMD"
-        eval $CMD
+        FIRST_OUTPUT=""
+
+        for RAW_OUTPUT in "${OUTPUTS[@]}"; do
+          ENTRY="$(echo "$RAW_OUTPUT" | xargs)"
+
+          # Skip empty lines
+          if [ -z "$ENTRY" ]; then
+            continue
+          fi
+
+          # Extract path and query params
+          OUTPUT_PATH_REL="${ENTRY%%\?*}"
+          OUTPUT_PALETTE="$THEME"
+          OUTPUT_FORMAT=""
+
+          if [[ "$ENTRY" == *"?"* ]]; then
+            QUERY_STRING="${ENTRY#*\?}"
+            IFS='&' read -ra PARAMS <<< "$QUERY_STRING"
+            for PARAM in "${PARAMS[@]}"; do
+              KEY="${PARAM%%=*}"
+              VALUE="${PARAM#*=}"
+              case "$KEY" in
+                palette)
+                  OUTPUT_PALETTE="$VALUE"
+                  ;;
+                format)
+                  OUTPUT_FORMAT="$VALUE"
+                  ;;
+              esac
+            done
+          fi
+
+          if [ -z "$FIRST_OUTPUT" ]; then
+            FIRST_OUTPUT="$OUTPUT_PATH_REL"
+          fi
+
+          OUTPUT_PATH_ABS="${WORKSPACE}/${OUTPUT_PATH_REL}"
+
+          CMD=("${CMD_BASE[@]}" -t "$OUTPUT_PALETTE" -o "$OUTPUT_PATH_ABS")
+          if [ -n "$OUTPUT_FORMAT" ]; then
+            CMD+=( -f "$OUTPUT_FORMAT" )
+          fi
+
+          echo "Running: ${CMD[*]}"
+          "${CMD[@]}"
+        done
 
         # Set output (relative path for user convenience)
-        echo "svg_path=$OUTPUT" >> $GITHUB_OUTPUT
+        if [ -n "$FIRST_OUTPUT" ]; then
+          echo "svg_path=$FIRST_OUTPUT" >> $GITHUB_OUTPUT
+        fi

--- a/action.yml
+++ b/action.yml
@@ -130,7 +130,10 @@ runs:
           fi
 
           echo "Running: ${CMD[*]}"
-          "${CMD[@]}"
+          if ! "${CMD[@]}"; then
+            echo "Error: Failed to generate output for: $OUTPUT_PATH_REL"
+            exit 1
+          fi
         done
 
         # Set output (relative path for user convenience)

--- a/action.yml
+++ b/action.yml
@@ -114,6 +114,16 @@ runs:
 
           OUTPUT_PATH_ABS="${WORKSPACE}/${OUTPUT_PATH_REL}"
 
+          # Validate path is within workspace (resolve symlinks and check prefix)
+          RESOLVED_PATH="$(cd "$(dirname "$OUTPUT_PATH_ABS")" 2>/dev/null && pwd -P)/$(basename "$OUTPUT_PATH_ABS")" || {
+            echo "Error: Invalid output path: $OUTPUT_PATH_REL"
+            continue
+          }
+          if [[ "$RESOLVED_PATH" != "$WORKSPACE"* ]]; then
+            echo "Error: Output path escapes workspace: $OUTPUT_PATH_REL"
+            continue
+          fi
+
           CMD=("${CMD_BASE[@]}" -t "$OUTPUT_PALETTE" -o "$OUTPUT_PATH_ABS")
           if [ -n "$OUTPUT_FORMAT" ]; then
             CMD+=( -f "$OUTPUT_FORMAT" )


### PR DESCRIPTION
## Summary
- parse outputs input by commas or newlines and invoke the CLI once per entry with optional per-output palette/format overrides
- ensure each output is written inside github.workspace while keeping the first output exposed as the action result
- update GitHub Action docs and examples to demonstrate the new outputs syntax

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6946a7c18698832e9437b11a7cf04e45)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple outputs with comma or newline separation
  * Added per-output optional query parameters (palette and format) to override theme and format settings

* **Documentation**
  * Updated README to explain the new outputs behavior, including per-output query parameters and workspace placement

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->