### PR TITLE
Fix frame delay handling in renderer and CLI

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,7 +34,11 @@ program
   .option("--token <token>", "GitHub personal access token for higher rate limits")
   .option("--animated", "Generate animated SVG (default: true)", true)
   .option("--static", "Generate static SVG (single frame)")
-  .option("--frame-delay <ms>", "Delay between frames in ms", "150")
+  .option("--frame-delay <ms>", "Delay between frames in ms (default: 150)", "150")
+  .option(
+    "-d, --duration <seconds>",
+    "Total animation duration in seconds (overrides frame delay when set)",
+  )
   .option("--max-length <n>", "Maximum snake length (0 = auto)", "0")
   .option("--grow-every <n>", "Grow 1 segment every N contributions (0 = auto)", "0")
   .action(async (options) => {
@@ -43,6 +47,14 @@ program
     console.log(`   Theme: ${options.theme}`);
     console.log(`   Format: ${options.format}`);
     console.log(`   Year: ${options.year}`);
+    console.log(
+      `   Frame delay: ${Number.parseInt(options.frameDelay, 10)}ms${
+        options.duration ? " (duration override enabled)" : ""
+      }`,
+    );
+    if (options.duration) {
+      console.log(`   Duration: ${options.duration}s`);
+    }
     console.log("");
 
     try {
@@ -79,6 +91,7 @@ program
 
       // Render
       let output: string;
+      const duration = options.duration ? Number.parseFloat(options.duration) : undefined;
       const renderOptions = {
         palette,
         frameDelay: Number.parseInt(options.frameDelay, 10),
@@ -86,7 +99,10 @@ program
 
       if (options.format === "gif") {
         console.log("🎬 GIF generation not yet implemented, falling back to animated SVG");
-        output = renderAnimatedSVG(frames, renderOptions);
+        output = renderAnimatedSVG(frames, {
+          ...renderOptions,
+          ...(duration ? { duration } : {}),
+        });
       } else if (options.static) {
         console.log("🖼️  Rendering static SVG...");
         const lastFrame = frames[frames.length - 1];
@@ -99,6 +115,7 @@ program
         console.log("🎬 Rendering animated SVG...");
         output = renderAnimatedSVG(frames, {
           ...renderOptions,
+          ...(duration ? { duration } : {}),
           loop: true,
         });
       }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -125,8 +125,11 @@ export function renderAnimatedSVG(
   const opts = { ...DEFAULT_OPTIONS, ...options };
   const { cellSize, gap, palette } = opts;
 
-  // Duration in seconds (faster default: 60ms per frame)
-  const frameDurationMs = options.duration ? (options.duration * 1000) / frames.length : 60;
+  // Duration in seconds derived from provided duration or frame delay (fallback 60ms)
+  const frameDurationMs =
+    options.duration !== undefined && options.duration !== null
+      ? (options.duration * 1000) / frames.length
+      : opts.frameDelay ?? 60;
   const totalDurationS = (frames.length * frameDurationMs) / 1000;
   const loop = options.loop ?? true;
 

--- a/packages/renderer/src/renderer.test.ts
+++ b/packages/renderer/src/renderer.test.ts
@@ -222,6 +222,13 @@ describe("Renderer - Animated SVG", () => {
       expect(svg).toMatch(/dur="10(\.00)?s"/);
     });
 
+    test("should derive duration from frameDelay when provided", () => {
+      const frames = createMockFrames();
+      const svg = renderAnimatedSVG(frames, { frameDelay: 200 });
+
+      expect(svg).toContain('dur="0.60s"');
+    });
+
     test("should set repeatCount to indefinite by default", () => {
       const frames = createMockFrames();
       const svg = renderAnimatedSVG(frames);


### PR DESCRIPTION
## Summary
- derive animated SVG durations from the configured frame delay with a 60ms fallback
- update CLI options and logging to surface frame delay and optional duration overrides
- add a renderer test to validate animate duration changes when frameDelay is set

## Testing
- bun test packages/renderer/src/renderer.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6946a79e5404832eac11b843dfef3f4d)